### PR TITLE
Fix typo in PEP listing

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -82,7 +82,7 @@
 
 <h2>PEP</h2>
 <p>
-	Showing hte latest stable release for PEP.
+	Showing the latest stable release for PEP.
 	<a href="/pep/">See all versions of PEP</a>.
 </p>
 


### PR DESCRIPTION
Fixing minor typo I noticed on http://code.jquery.com/