### PR TITLE
Build: Improve docs around config.json file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -424,9 +424,10 @@ grunt.registerTask( "ensure-dist-resources", function() {
 } );
 
 grunt.registerTask( "ensure-wordpress-config", function() {
-	// This will fail with "Cannot find module" if the file
-	// does not exist
+	// Fail with "Cannot find module" if the file does not exist
 	var config = require( "./config" );
+	// On jq-builder hosts, Puppet provisions config.json with wp credentials.
+	// See also jquery::siteupdater in jquery/infrastucture [private].
 	config.dir = "dist/wordpress";
 	grunt.config.merge( {
 		wordpress: config

--- a/config-sample.json
+++ b/config-sample.json
@@ -3,7 +3,9 @@
 	"username": "admin",
 	"password": "secret",
 	"cdn": {
+		"alias": "jquery",
 		"consumer_key": "key",
-		"consumer_secret": "secret"
+		"consumer_secret": "secret",
+		"zone_id": 0
 	}
 }

--- a/purge.php
+++ b/purge.php
@@ -2,6 +2,8 @@
 require_once( 'netdnarws-php/NetDNA.php' );
 
 $config = json_decode( file_get_contents( './config.json' ), true );
+// On jq-wp hosts, Puppet provisions config.json with cdn credentials.
+// See also jquery::wp::jquery#codeorigin in jquery/infrastucture [private].
 $config = $config[ 'cdn' ];
 $zone_id = $config[ 'zone_id' ];
 
@@ -17,8 +19,15 @@ $file = $parts[ 0 ];
 header( 'Content-Type: text/plain' );
 echo "Attempting to purge: $zone_id: $file.\n";
 
-$api = new NetDNA( 'jquery', $config[ 'consumer_key' ], $config[ 'consumer_secret' ] );
-$result = $api->delete( '/zones/pull.json/' . $zone_id . '/cache', array( 'file' => $file ) );
+$api = new NetDNA(
+	$config[ 'alias' ],
+	$config[ 'consumer_key' ],
+	$config[ 'consumer_secret' ]
+);
+$result = $api->delete(
+	'/zones/pull.json/' . $zone_id . '/cache',
+	array( 'file' => $file )
+);
 $result = json_decode( $result, true );
 
 if ( $result[ 'code' ] !== 200 ) {


### PR DESCRIPTION
There are two versions of this file on different jq servers internally,
one with just the wp stuff, one with just the cdn stuff.

Update the sample file to match the keys that exist in reality.
Specifically, the sample was missing the 'zone_id' field that
we were already depending on in purge.php.
The sample was also missing the 'alias' field that we
set in production. Make use of this field instead of hardcoding
"jquery" so that things are easier to update quickly when needed.