### PR TITLE
purge: Fix CDN purge script (enable `purgeAllDynamic` option)

### DIFF
--- a/purge.php
+++ b/purge.php
@@ -37,7 +37,7 @@ if ( !$hwConfig
 
 // The StrikeTracker Purge API is protocol-sensitive.
 // HTTP and HTTPS need to be purged separately, or
-// we can use a protocol-relative file url, which HW
+// we can use a protocol-relative file url, which Highwinds
 // supports as short-cut for purging both.
 $file = "//{$hwConfig->file_hostname}/" . ltrim( $_SERVER[ 'REQUEST_URI' ], '/' );
 
@@ -73,10 +73,10 @@ $result = jq_request_post_json(
 		"Authorization: Bearer {$hwConfig->api_token}",
 		"Content-Type: application/json",
 	),
-	// post body (JSON)
+	// post body (will be encoded as JSON)
 	array(
 		'list' => array(
-			array( 'url' => $file ),
+			array( 'url' => $file, 'purgeAllDynamic' => true ),
 		),
 	)
 );


### PR DESCRIPTION
While not yet documented or announced, it seems the Purge API
from StackPath/Highwinds/StrikeTracker no longer purges variants
by default as of October this year.

The old behaviour can be regained through the undocumented
`purgeAllDynamic` boolean option which appears to be false
by default.

I'm not sure what variants we have that cause this behaviour, but
it might be due to something like Vary:Accepted-Encoding (gzip etc.).

Fixes #45.