### PR TITLE
Build: Prepare for releases.jquery.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /dist/
+/git/
 /config.js*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -304,9 +304,19 @@ grunt.registerTask( "build-index", function() {
 
 	var sriHashes = require( "./dist/resources/sri-directives.json" );
 
-	function href( file, label ) {
-		var sri = "sha256-" + sriHashes["@cdn/" + file]["hashes"]["sha256"];
-		return "<a class='open-sri-modal' href='/" + file + "' data-hash='" + sri + "'>" + label + "</a>";
+	function cdnLink( file, label ) {
+		var cdnOrigin = grunt.config( "wordpress" ).cdn_origin;
+		return `<a href='${ cdnOrigin }/${ file }'>${ label }</a>`;
+	}
+
+	function cdnSriLink( file, label ) {
+		var cdnOrigin = grunt.config( "wordpress" ).cdn_origin,
+			sri = "sha256-" + sriHashes[ `@cdn/${ file }` ].hashes.sha256;
+		return `<a
+			class='open-sri-modal'
+			href='${ cdnOrigin }/${ file }'
+			data-hash='${ sri }'
+		>${ label }</a>`;
 	}
 
 	Handlebars.registerHelper( "ifeq", function( v1, v2, options ) {
@@ -316,30 +326,48 @@ grunt.registerTask( "build-index", function() {
 		return options.inverse( this );
 	} );
 
-	Handlebars.registerHelper( "sriLink", function( file, label ) {
-		return new Handlebars.SafeString( href( file, label ) );
+	Handlebars.registerHelper( "concat2",function( p1, p2 ) {
+		return `${ p1 }${ p2 }`;
+	} );
+	Handlebars.registerHelper( "concat3",function( p1, p2, p3 ) {
+		return `${ p1 }${ p2 }${ p3 }`;
+	} );
+	Handlebars.registerHelper( "concat4",function( p1, p2, p3, p4 ) {
+		return `${ p1 }${ p2 }${ p3 }${ p4 }`;
+	} );
+	Handlebars.registerHelper( "concat5",function( p1, p2, p3, p4, p5 ) {
+		return `${ p1 }${ p2 }${ p3 }${ p4 }${ p5 }`;
+	} );
+
+	Handlebars.registerHelper( "cdnLink", function( file, label ) {
+		return new Handlebars.SafeString( cdnLink( file, label ) );
+	} );
+	Handlebars.registerHelper( "cdnSriLink", function( file, label ) {
+		return new Handlebars.SafeString( cdnSriLink( file, label ) );
 	} );
 
 	Handlebars.registerHelper( "release", function( prefix, release ) {
-		var html = prefix + " " + release.version + " - " + href( release.filename, "uncompressed" );
+		var html = prefix + " " + release.version + " - " + cdnSriLink( release.filename, "uncompressed" );
 		if ( release.minified ) {
-			html += ", " + href( release.minified, "minified" );
+			html += ", " + cdnSriLink( release.minified, "minified" );
 		}
 		if ( release.packed ) {
-			html += ", " + href( release.packed, "packed" );
+			html += ", " + cdnSriLink( release.packed, "packed" );
 		}
 		if ( release.slim ) {
-			html += ", " + href( release.slim, "slim" );
+			html += ", " + cdnSriLink( release.slim, "slim" );
 		}
 		if ( release.slimMinified ) {
-			html += ", " + href( release.slimMinified, "slim minified" );
+			html += ", " + cdnSriLink( release.slimMinified, "slim minified" );
 		}
 
 		return new Handlebars.SafeString( html );
 	} );
 
 	Handlebars.registerHelper( "uiTheme", function( release ) {
-		var url;
+		var url,
+			cdnOrigin = grunt.config( "wordpress" ).cdn_origin;
+
 		// TODO: link to minified theme if available
 		if ( release.themes.indexOf( "smoothness" ) !== -1 ) {
 			url = "smoothness/jquery-ui.css";
@@ -348,7 +376,7 @@ grunt.registerTask( "build-index", function() {
 		}
 
 		return new Handlebars.SafeString(
-			"<a href='/ui/" + release.version + "/themes/" + url + "'>theme</a>" );
+			`<a href='${ cdnOrigin }/ui/${ release.version }/themes/${ url }'>theme</a>` );
 	} );
 
 	Handlebars.registerHelper( "include", (function() {

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,7 +1,8 @@
 {
-	"url": "vagrant.codeorigin.jquery.com",
+	"url": "vagrant.releases.jquery.com",
 	"username": "admin",
 	"password": "secret",
+	"cdn_origin": "https://code.jquery.com",
 
 	"highwinds": {
 		"api_url": "https://striketracker.highwinds.com",

--- a/templates/color-git.hbs
+++ b/templates/color-git.hbs
@@ -4,14 +4,14 @@
 <ul>
 	<li>
 		jQuery Color git build -
-		<a href="/color/jquery.color-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color-git.js">uncompressed</a>
 	</li>
 	<li>
 		jQuery Color SVG Color Names git build -
-		<a href="/color/jquery.color.svg-names-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color.svg-names-git.js">uncompressed</a>
 	</li>
 	<li>
 		jQuery Color With Names (last two together) git build -
-		<a href="/color/jquery.color.plus-names-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color.plus-names-git.js">uncompressed</a>
 	</li>
 </ul>

--- a/templates/jquery-git.hbs
+++ b/templates/jquery-git.hbs
@@ -4,31 +4,31 @@
 <ul>
 	<li>
 		jQuery git build</a> -
-		<a href="/jquery-git.js">uncompressed</a>,
-		<a href="/jquery-git.min.js">minified</a>,
-		<a href="/jquery-git.slim.js">slim</a>,
-		<a href="/jquery-git.slim.min.js">slim minified</a>
+		<a href="/git/jquery-git.js">uncompressed</a>,
+		<a href="/git/jquery-git.min.js">minified</a>,
+		<a href="/git/jquery-git.slim.js">slim</a>,
+		<a href="/git/jquery-git.slim.min.js">slim minified</a>
 	</li>
 	<li>
 		jQuery 3.x git build</a> -
-		<a href="/jquery-3.x-git.js">uncompressed</a>,
-		<a href="/jquery-3.x-git.min.js">minified</a>,
-		<a href="/jquery-3.x-git.slim.js">slim</a>,
-		<a href="/jquery-3.x-git.slim.min.js">slim minified</a>
+		<a href="/git/jquery-3.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-3.x-git.min.js">minified</a>,
+		<a href="/git/jquery-3.x-git.slim.js">slim</a>,
+		<a href="/git/jquery-3.x-git.slim.min.js">slim minified</a>
 	</li>
 	<li>
 		jQuery 2.x git build</a> -
-		<a href="/jquery-2.x-git.js">uncompressed</a>,
-		<a href="/jquery-2.x-git.min.js">minified</a>
+		<a href="/git/jquery-2.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-2.x-git.min.js">minified</a>
 	</li>
 	<li>
 		jQuery 1.x git build</a> -
-		<a href="/jquery-1.x-git.js">uncompressed</a>,
-		<a href="/jquery-1.x-git.min.js">minified</a>
+		<a href="/git/jquery-1.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-1.x-git.min.js">minified</a>
 	</li>
 	<li>
 		jQuery Migrate git build</a> -
-		<a href="/jquery-migrate-git.js">uncompressed</a>,
-		<a href="/jquery-migrate-git.min.js">minified</a>
+		<a href="/git/jquery-migrate-git.js">uncompressed</a>,
+		<a href="/git/jquery-migrate-git.min.js">minified</a>
 	</li>
 </ul>

--- a/templates/mobile-git.hbs
+++ b/templates/mobile-git.hbs
@@ -4,9 +4,9 @@
 <ul>
 	<li>
 		jQuery Mobile git build -
-		<a href="/mobile/git/jquery.mobile-git.js">uncompressed</a>,
-		<a href="/mobile/git/jquery.mobile-git.min.js">minified</a>,
-		<a href="/mobile/git/jquery.mobile-git.css">theme</a>
-		(<a href="/mobile/git/jquery.mobile-git.min.css">minified</a>)
+		<a href="/git/mobile/git/jquery.mobile-git.js">uncompressed</a>,
+		<a href="/git/mobile/git/jquery.mobile-git.min.js">minified</a>,
+		<a href="/git/mobile/git/jquery.mobile-git.css">theme</a>
+		(<a href="/git/mobile/git/jquery.mobile-git.min.css">minified</a>)
 	</li>
 </ul>

--- a/templates/mobile-release.hbs
+++ b/templates/mobile-release.hbs
@@ -1,9 +1,9 @@
 <li>
 	jQuery Mobile {{version}} -
-	<a href="/{{filename}}">uncompressed</a>,
-	<a href="/{{minified}}">minified</a>,
-	<a href="/{{minifiedCss}}">theme</a>
+	{{cdnSriLink filename "uncompressed"}},
+	{{cdnSriLink minified "minified"}},
+	{{cdnLink minifiedCss "theme"}}
 	{{#if minifiedStructure}}
-		(<a href="/{{minifiedStructure}}">structure only</a>)
+		({{cdnLink minifiedStructure "structure only"}})
 	{{/if}}
 </li>

--- a/templates/pep-release.hbs
+++ b/templates/pep-release.hbs
@@ -1,5 +1,5 @@
 <li>
 	PEP {{version}} -
-	<a href="/{{filename}}">uncompressed</a>,
-	<a href="/{{minified}}">minified</a>
+	{{cdnSriLink filename "uncompressed"}},
+	{{cdnSriLink minified "minified"}}
 </li>

--- a/templates/qunit-release.hbs
+++ b/templates/qunit-release.hbs
@@ -1,5 +1,5 @@
 <li>
 	QUnit {{version}} -
-	{{sriLink filename "uncompressed"}},
-	{{sriLink theme "theme"}}
+	{{cdnLink filename "uncompressed"}},
+	{{cdnLink theme "theme"}}
 </li>

--- a/templates/ui-git.hbs
+++ b/templates/ui-git.hbs
@@ -4,7 +4,7 @@
 <ul>
 	<li>
 		jQuery UI git build</a> -
-		<a href="/ui/jquery-ui-git.js">uncompressed</a>,
-		<a href="/ui/jquery-ui-git.css">theme</a>
+		<a href="/git/ui/jquery-ui-git.js">uncompressed</a>,
+		<a href="/git/ui/jquery-ui-git.css">theme</a>
 	</li>
 </ul>

--- a/templates/ui-latest.hbs
+++ b/templates/ui-latest.hbs
@@ -4,7 +4,7 @@
 	<li>{{release "jQuery UI" this}}</li>
 	<li>Themes:
 		{{#each themes}}
-			<a href="/ui/{{../version}}/themes/{{this}}/jquery-ui.css">{{this}}</a>
+			{{cdnLink (concat5 "ui/" ../version "/themes/" this "/jquery-ui.css") this}}
 		{{/each}}
 	</li>
 </ul>

--- a/templates/ui.hbs
+++ b/templates/ui.hbs
@@ -10,7 +10,7 @@
 		{{release "jQuery UI" latestStable}}
 		<h3>Themes</h3>
 		{{#each latestStable.themes}}
-			<a href="/ui/{{../latestStable/version}}/themes/{{this}}/jquery-ui.css">{{this}}</a>
+			{{cdnLink (concat5 "ui/" ../latestStable/version "/themes/" this "/jquery-ui.css") this}}
 		{{/each}}
 	{{/if}}
 	{{#if all.length}}


### PR DESCRIPTION
1. Point CDN links directly to https://code.jquery.com.
2. Add a separate helper for non-SRI CDN links. This is mostly used for CSS
which, in theory, could also have SRI applied but that would require changes to
the SRI plugin so we're leaving CSS without SRI for now.
3. Git files are now served from the `/git/` directory.
4. Add config-sample.json with the new required cdn_origin field.