### PR TITLE
Build: Switch URLs for git files to use `/git`/ directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /dist/
+/git/
 /config.js*

--- a/templates/color-git.hbs
+++ b/templates/color-git.hbs
@@ -4,14 +4,14 @@
 <ul>
 	<li>
 		jQuery Color git build -
-		<a href="/color/jquery.color-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color-git.js">uncompressed</a>
 	</li>
 	<li>
 		jQuery Color SVG Color Names git build -
-		<a href="/color/jquery.color.svg-names-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color.svg-names-git.js">uncompressed</a>
 	</li>
 	<li>
 		jQuery Color With Names (last two together) git build -
-		<a href="/color/jquery.color.plus-names-git.js">uncompressed</a>
+		<a href="/git/color/jquery.color.plus-names-git.js">uncompressed</a>
 	</li>
 </ul>

--- a/templates/jquery-git.hbs
+++ b/templates/jquery-git.hbs
@@ -4,31 +4,31 @@
 <ul>
 	<li>
 		jQuery git build</a> -
-		<a href="/jquery-git.js">uncompressed</a>,
-		<a href="/jquery-git.min.js">minified</a>,
-		<a href="/jquery-git.slim.js">slim</a>,
-		<a href="/jquery-git.slim.min.js">slim minified</a>
+		<a href="/git/jquery-git.js">uncompressed</a>,
+		<a href="/git/jquery-git.min.js">minified</a>,
+		<a href="/git/jquery-git.slim.js">slim</a>,
+		<a href="/git/jquery-git.slim.min.js">slim minified</a>
 	</li>
 	<li>
 		jQuery 3.x git build</a> -
-		<a href="/jquery-3.x-git.js">uncompressed</a>,
-		<a href="/jquery-3.x-git.min.js">minified</a>,
-		<a href="/jquery-3.x-git.slim.js">slim</a>,
-		<a href="/jquery-3.x-git.slim.min.js">slim minified</a>
+		<a href="/git/jquery-3.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-3.x-git.min.js">minified</a>,
+		<a href="/git/jquery-3.x-git.slim.js">slim</a>,
+		<a href="/git/jquery-3.x-git.slim.min.js">slim minified</a>
 	</li>
 	<li>
 		jQuery 2.x git build</a> -
-		<a href="/jquery-2.x-git.js">uncompressed</a>,
-		<a href="/jquery-2.x-git.min.js">minified</a>
+		<a href="/git/jquery-2.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-2.x-git.min.js">minified</a>
 	</li>
 	<li>
 		jQuery 1.x git build</a> -
-		<a href="/jquery-1.x-git.js">uncompressed</a>,
-		<a href="/jquery-1.x-git.min.js">minified</a>
+		<a href="/git/jquery-1.x-git.js">uncompressed</a>,
+		<a href="/git/jquery-1.x-git.min.js">minified</a>
 	</li>
 	<li>
 		jQuery Migrate git build</a> -
-		<a href="/jquery-migrate-git.js">uncompressed</a>,
-		<a href="/jquery-migrate-git.min.js">minified</a>
+		<a href="/git/jquery-migrate-git.js">uncompressed</a>,
+		<a href="/git/jquery-migrate-git.min.js">minified</a>
 	</li>
 </ul>

--- a/templates/mobile-git.hbs
+++ b/templates/mobile-git.hbs
@@ -4,9 +4,9 @@
 <ul>
 	<li>
 		jQuery Mobile git build -
-		<a href="/mobile/git/jquery.mobile-git.js">uncompressed</a>,
-		<a href="/mobile/git/jquery.mobile-git.min.js">minified</a>,
-		<a href="/mobile/git/jquery.mobile-git.css">theme</a>
-		(<a href="/mobile/git/jquery.mobile-git.min.css">minified</a>)
+		<a href="/git/mobile/git/jquery.mobile-git.js">uncompressed</a>,
+		<a href="/git/mobile/git/jquery.mobile-git.min.js">minified</a>,
+		<a href="/git/mobile/git/jquery.mobile-git.css">theme</a>
+		(<a href="/git/mobile/git/jquery.mobile-git.min.css">minified</a>)
 	</li>
 </ul>

--- a/templates/ui-git.hbs
+++ b/templates/ui-git.hbs
@@ -4,7 +4,7 @@
 <ul>
 	<li>
 		jQuery UI git build</a> -
-		<a href="/ui/jquery-ui-git.js">uncompressed</a>,
-		<a href="/ui/jquery-ui-git.css">theme</a>
+		<a href="/git/ui/jquery-ui-git.js">uncompressed</a>,
+		<a href="/git/ui/jquery-ui-git.css">theme</a>
 	</li>
 </ul>


### PR DESCRIPTION
Git files are now served from the `/git/` directory.

Support for this was added on the server in the private commit
at https://github.com/jquery/infrastructure/commit/aeae9f8728b.

This is in preparation for a new browser at releases.jquery.com,
and that server will only support `/git/` for these files.

The codeorigin server will supporting both the top-level access
and /git/ access, by making them redirect to releases.jquery.com.

Ref https://github.com/jquery/codeorigin.jquery.com/pull/70.