### PR TITLE
Publish machine-readable file list and SRI data to resources/ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
 /dist/
+/resources/sri-directives.json
 /git/
 /config.js*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,15 @@ grunt.initConfig( {
 				dest: "dist/resources/sri-directives.json"
 			}
 		}
-	}
+	},
+
+	wordpress: (function() {
+
+		// This fails with "Cannot find module" if the file does not exist
+		var config = require( "./config" );
+		config.dir = "dist/wordpress";
+		return config;
+	})()
 } );
 
 grunt.registerTask( "build-index", function() {
@@ -453,22 +461,12 @@ grunt.registerTask( "ensure-dist-resources", function() {
 	grunt.file.mkdir( "dist/resources" );
 } );
 
-grunt.registerTask( "ensure-wordpress-config", function() {
-	// This will fail with "Cannot find module" if the file
-	// does not exist
-	var config = require( "./config" );
-	config.dir = "dist/wordpress";
-	grunt.config.merge( {
-		wordpress: config
-	} );
-} );
-
 grunt.registerTask( "sri-generate", ["ensure-dist-resources", "sri:generate"] );
 
 // The "grunt deploy" command is automatically invoked on git-commit by the server that
 // will deploy the WordPress site.
 // Task tree: "deploy" > "wordpress-deploy" > "build-wordpress" > "build".
 grunt.registerTask( "build", ["sri-generate", "build-index"] );
-grunt.registerTask( "deploy", ["ensure-wordpress-config", "wordpress-deploy", "reload-listings"] );
+grunt.registerTask( "deploy", ["wordpress-deploy", "reload-listings"] );
 
 };


### PR DESCRIPTION
Let "wordpress-deploy" upload this to the site, which the gw-resources plugin exposes via addresses like <https://releases.jquery.com/resources/foo>.

See <https://github.com/jquery/api.jquery.com/> for an example of this.

Local test plan:

```
nobody$ npm ci
nobody$ cp config-sample.json config.json

nobody$ ./node_modules/.bin/grunt sri
nobody$ less resources/sri-directives.json
  {"@cdn/color/2.2.0/jquery.color.js":{"hashes":{"sha256":"gvMJWDH...

nobody$ ./node_modules/.bin/grunt build-index build-resources
nobody$ less dist/wordpress/resources/sri-directives.json
  {"@cdn/color/2.2.0/jquery.color.js":{"hashes":{"sha256":"gvMJWDH...
nobody$ less dist/wordpress/resources/cdn.json
  { "jquery": [ [ "3", { "latestStable": {
  "filename": "jquery-3.6.0.js", ...
```

Closes #40.