### PR TITLE
Dockerfile: Various bug fixes, clean ups, and an integration test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,36 @@
-FROM nginx:alpine
+# Allow patch updates
+# https://hub.docker.com/_/nginx/
+FROM nginx:1-alpine
 
-# Install pre-reqs, since we're doing everything in one container for minimum complexity
 RUN apk add vim openrc
+
+# Add CDN assets to the container
+#
+# This is an early step in the Dockerfile, so that local docker builds
+# can reuse this layer and perform a fast rebuild when you only tweaked
+# later stuff (nginx config, args, etc.)
+COPY cdn/ /var/www/cdn/
+
+# Set a constant file modification timestamp for all CDN assets
+#
+# Git does not store modified file timestamps, which means the on-disk mtime
+# for most files is set to the time of the Git clone. This is a problem
+# since the container-based server will be re-created after each commit,
+# and we do not want the public "Last-Modified" and "E-Tag" header information
+# to roll over after every rebuild.
+#
+# While Apache has an option to configure how E-Tag is computed (e.g. based on
+# content only), Nginx is always based on file mtime and file size.
+#
+# As a workaround, set a fixed timestamp for all CDN files. This is okay as
+# we don't actually utilized Last-Modified or E-Tag for propagating changes,
+# we only use them as a way to re-assure browsers that files haven't changed
+# and thus reduce bandwidth from needless re-transfers. Given our maximum
+# Cache-Control "max-age", it is already the case that a changed file will not
+# be seen by the CDN unless we purge it via the CDN API, and not seen by previous
+# browser clients until they clear their own caches.
+#
+RUN find /var/www/cdn/ -type f -print0 | TZ=UTC xargs -0 -P 4 -n 50 touch --date='1991-10-18 12:00:00' {} +
 
 # Define the environment variable that will be used in the origin pull magic header
 ARG CDN_ACCESS_KEY=''
@@ -11,19 +40,16 @@ COPY cfg/vimrc /etc/vim/vimrc
 COPY cfg/default.conf /etc/nginx/conf.d/default.conf
 
 # If the CDN_ACCESS_KEY environment variable is *not* set, operate in "break glass" mode where the
-# container responds to all requests. Otherwise, look for the secret header the CDN adds to origin
-# pulls and only allow responses to those requests, and 301 the rest back to the CDN.
+# container serves files without restriction. Otherwise, it responds with redirects to requests
+# that don't carry an x-cdn-access request header with the correct key.
 #
-# Note: We're writing directly to the config files because nginx does not currently have a way to
-# access environment variables without significant workarounds. Furthermore, the variables are
-# required because nginx does not currently support nested if statements.
+# Note: We're substituting the config file because nginx does not currently have a way to
+# access environment variables without significant workarounds.
 RUN if [ -n "$CDN_ACCESS_KEY" ]; then \
-    sed -i s/CDN_ACCESS_KEY_PLACEHOLDER/$CDN_ACCESS_KEY/g /etc/nginx/conf.d/default.conf && \
-    sed -i s/##ACTIVATE-XCDNACCESS##//g /etc/nginx/conf.d/default.conf; \
+    sed -i s/CDN_ACCESS_KEY_PLACEHOLDER/$CDN_ACCESS_KEY/g /etc/nginx/conf.d/default.conf; \
+  else \
+    sed -i s/^.*REQUIRE_XCDNACCESS$//g /etc/nginx/conf.d/default.conf; \
   fi
-
-# Load the releases into the container
-COPY cdn/ /usr/share/nginx/html/
 
 EXPOSE 80
 

--- a/cfg/30-start-php-fpm7.sh
+++ b/cfg/30-start-php-fpm7.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-php-fpm7 -D

--- a/cfg/default.conf
+++ b/cfg/default.conf
@@ -15,155 +15,112 @@
 # Increase map_hash_bucket_size to accommodate longer CDN tokens
 map_hash_bucket_size 128;
 
-# Do not change the following lines. The Dockerfile will set the access key and remove the comment
-# at build time if the correct environment variable is set.
-##ACTIVATE-XCDNACCESS##map $http_x_cdn_access $reroute_to_cdn { default '1'; CDN_ACCESS_KEY_PLACEHOLDER '0'; }
+# Do not change the following line. The Dockerfile will insert the access key or remove the line.
+map $http_x_cdn_access $reroute_to_cdn { default 1; CDN_ACCESS_KEY_PLACEHOLDER 0; } #REQUIRE_XCDNACCESS
 
 server {
   listen        80;
   listen        [::]:80;
   server_name   localhost;
 
-  access_log  /var/log/nginx/host.access.log  main;
+  # Turn off access logs and ignore most errors (eg. files not found etc.)
+  #
+  # docker-nginx provisions error.log as a symlink to /dev/stderr, which means they will not
+  # be stored on disk in the container, but written to docker operator.
+  # This is either your terminal, or the built-in logs handler of the application platform.
+  #
+  # For detailed logging during development about how nginx evaluates the location blocks
+  # and pattern matches, change "crit" to "debug", and then build/run the container.
+  access_log    off;
+  error_log     /var/log/nginx/error.log crit;
 
+  # Reduce overhead, and obsure server version
+  server_tokens off;
+
+  ##
+  # Main location block for static assets
+  ##
   location / {
-    root        /usr/share/nginx/html;
-    index       index.html index.htm;
+    root /var/www/cdn;
 
-    # Do not change the following line. The Dockerfile will set the access key and remove the
-    # comment at build time if the correct environment variable is set.
-    ##ACTIVATE-XCDNACCESS##if ($reroute_to_cdn) { return 301 https://code2.jquery.com$uri; }
+    # Enable GZIP beyond just text/html
+    # https://stackoverflow.com/a/6475493/319266
+    gzip_types text/plain text/xml application/xml text/css text/javascript application/javascript application/x-javascript text/x-component application/json application/xhtml+xml application/rss+xml application/atom+xml application/vnd.ms-fontobject image/svg+xml application/x-font-ttf font/opentype;
 
-  }
-
-  # PHP configuration for purge.php
-
-  location ~ \.php$ {
-    root           /usr/share/nginx/html;
-    fastcgi_pass   127.0.0.1:9000;
-    fastcgi_index  index.php;
-    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-    include        fastcgi_params;
-  }
-
-  # Redirect requests to the root to the release viewer
-
-  location ~ ^/(?:/)?$ {
-    expires off;
+    add_header Cache-Control public;
+    add_header Access-Control-Allow-Origin *;
+    expires max;
     gzip on;
-    return 301 https://releases.jquery.com;
+    gzip_comp_level 9;
+    gzip_vary on;
+
+    # Applies to charset_types (mainly for JS and CSS)
+    charset utf-8;
+
+    # Do not change the following line. The Dockerfile will remove the line if needed.
+    if ($reroute_to_cdn) { return 301 https://code.jquery.com$uri; } #REQUIRE_XCDNACCESS
   }
 
-  # Redirect requests to paths known to be non-release files (e.g., git versions and their assets)
-  # to the viewer. Jenkins needs access to the host that delivers these files, and codeorigin is
-  # intended to be more tightly managed via github repo.
+  # Legacy redirects for renamed files
+  location = /jquery-git1.js { return 301 https://code.jquery.com/jquery-git.js; }
+  location = /jquery-git2.js { return 301 https://code.jquery.com/jquery-git.js; }
+  location = /jquery-compat-git.js { return 301 https://code.jquery.com/jquery-git.js; }
+  location = /jquery-git1.min.js { return 301 https://code.jquery.com/jquery-git.min.js; }
+  location = /jquery-git2.min.js { return 301 https://code.jquery.com/jquery-git.min.js; }
+  location = /jquery-compat-git.min.js { return 301 https://code.jquery.com/jquery-git.min.js; }
 
-  # Redirect to releases.jquery.com/
+  ##
+  # Redirects for WordPress pages and Jenkins artefacts that were previously
+  # served at code.jquery.com but are now at releases.jquery.com.
+  #
+  # Ref <https://github.com/jquery/infrastructure/issues/474#issuecomment-844582865>.
+  #
+  # Prefer $uri over $request_uri, <https://stackoverflow.com/a/48709976/319266>.
+  ##
 
-  location ~ ^/git(?:/(.*))? {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com$request_uri;
-  }
+  # Domain root, and WordPress pages (canonically with trailing slash)
+  location = / { return 301 https://releases.jquery.com/; }
+  location = /jquery/ { return 301 https://releases.jquery.com$uri; }
+  location = /ui/ { return 301 https://releases.jquery.com$uri; }
+  location = /mobile/ { return 301 https://releases.jquery.com$uri; }
+  location = /color/ { return 301 https://releases.jquery.com$uri; }
+  location = /qunit/ { return 301 https://releases.jquery.com$uri; }
+  location = /pep/ { return 301 https://releases.jquery.com$uri; }
 
-  # Redirect specific project pages to releases.jquery.com
-  location ~ ^/jquery(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/jquery/;
-  }
+  # Legacy redirects to append trailing slash
+  location = /jquery { return 301 https://releases.jquery.com$uri/; }
+  location = /ui { return 301 https://releases.jquery.com$uri/; }
+  location = /qunit { return 301 https://releases.jquery.com$uri/; }
+  location = /mobile { return 301 https://releases.jquery.com$uri/; }
+  location = /color { return 301 https://releases.jquery.com$uri/; }
 
-  location ~ ^/ui(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/ui/;
-  }
+  # Jenkins artefacts were pushed to an isolated area mounted as "/git/"
+  # on the codeorigin server. The contents were only accessible via a
+  # plethora of rewrites rules that made these files blend in among
+  # CDN assets from a URL prespective. For example:
+  #
+  # - "/ui/foo-1.2.3.js" would be served from "/cdn/ui/foo-1.2.3.js"
+  # - "/ui/foo-git.js" would be served from "/git/ui/foo-git.js".
+  #
+  # Full list at:
+  # https://github.com/jquery/infrastructure/issues/474#issuecomment-844582865
+  #
+  location ~* -git\. { return 301 https://releases.jquery.com/git$uri; }
+  location /mobile/git/ { return 301 https://releases.jquery.com/git$uri; }
 
-  location ~ ^/mobile(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/mobile/;
-  }
-
-  location ~ ^/color(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/color/;
-  }
-
-  location ~ ^/qunit(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/qunit/;
-  }
-
-  location ~ ^/pep(?:/)?$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/pep/;
-  }
-
-  # Redirect to releases.jquery.com/git/
-
-  location ~* -git\.(js|min.js|slim.js|slim.min.js|css)$ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/git$request_uri;
-  }
-
-  location ^~ /mobile/git/ {
-    expires off;
-    gzip on;
-    return 301 https://releases.jquery.com/git$request_uri;
-  }
-
-  # Redirect some known legacy URLs that may still point to code.jquery.com. This list is a
-  # workaround, and should not need to be expanded.
-
-  rewrite ^/ui/images/ui-icons_cc0000_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_cc0000_256x240.png permanent;
-  rewrite ^/ui/images/ui-icons_777777_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_777777_256x240.png permanent;
-  rewrite ^/ui/images/ui-icons_777620_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_777620_256x240.png permanent;
-  rewrite ^/ui/images/ui-icons_555555_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_555555_256x240.png permanent;
-  rewrite ^/ui/images/ui-icons_444444_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_444444_256x240.png permanent;
-  rewrite ^/ui/images/ui-bg_flat_0_aaaaaa_40x100\.png$ https://releases.jquery.com/git/ui/images/ui-bg_flat_0_aaaaaa_40x100.png permanent;
-  rewrite ^/ui/images/ui-icons_ffffff_256x240\.png$ https://releases.jquery.com/git/ui/images/ui-icons_ffffff_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_cc0000_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_cc0000_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_highlight-soft_75_cccccc_1x100\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_highlight-soft_75_cccccc_1x100.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_2e83ff_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_2e83ff_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_flat_75_ffffff_40x100\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_flat_75_ffffff_40x100.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_glass_95_fef1ec_1x400\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_glass_95_fef1ec_1x400.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_777777_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_777777_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_glass_65_ffffff_1x400\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_glass_65_ffffff_1x400.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_777620_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_777620_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_555555_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_555555_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_glass_75_e6e6e6_1x400\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_glass_75_e6e6e6_1x400.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_222222_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_222222_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_888888_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_888888_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_444444_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_444444_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_cd0a0a_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_cd0a0a_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_glass_55_fbf9ee_1x400\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_glass_55_fbf9ee_1x400.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_454545_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_454545_256x240.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_glass_75_dadada_1x400\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_glass_75_dadada_1x400.png permanent;
-  rewrite ^/ui/_images/images/ui-bg_flat_0_aaaaaa_40x100\.png$ https://releases.jquery.com/git/ui/_images/images/ui-bg_flat_0_aaaaaa_40x100.png permanent;
-  rewrite ^/ui/_images/images/ui-icons_ffffff_256x240\.png$ https://releases.jquery.com/git/ui/_images/images/ui-icons_ffffff_256x240.png permanent;
-  rewrite ^/ui/_images/ui-bg_highlight-soft_75_cccccc_1x100\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_highlight-soft_75_cccccc_1x100.png permanent;
-  rewrite ^/ui/_images/ui-icons_2e83ff_256x240\.png$ https://releases.jquery.com/git/ui/_images/ui-icons_2e83ff_256x240.png permanent;
-  rewrite ^/ui/_images/ui-bg_flat_75_ffffff_40x100\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_flat_75_ffffff_40x100.png permanent;
-  rewrite ^/ui/_images/ui-bg_glass_95_fef1ec_1x400\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_glass_95_fef1ec_1x400.png permanent;
-  rewrite ^/ui/_images/ui-bg_glass_65_ffffff_1x400\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_glass_65_ffffff_1x400.png permanent;
-  rewrite ^/ui/_images/ui-bg_glass_75_e6e6e6_1x400\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_glass_75_e6e6e6_1x400.png permanent;
-  rewrite ^/ui/_images/ui-icons_222222_256x240\.png$ https://releases.jquery.com/git/ui/_images/ui-icons_222222_256x240.png permanent;
-  rewrite ^/ui/_images/ui-icons_888888_256x240\.png$ https://releases.jquery.com/git/ui/_images/ui-icons_888888_256x240.png permanent;
-  rewrite ^/ui/_images/ui-icons_cd0a0a_256x240\.png$ https://releases.jquery.com/git/ui/_images/ui-icons_cd0a0a_256x240.png permanent;
-  rewrite ^/ui/_images/ui-bg_glass_55_fbf9ee_1x400\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_glass_55_fbf9ee_1x400.png permanent;
-  rewrite ^/ui/_images/ui-icons_454545_256x240\.png$ https://releases.jquery.com/git/ui/_images/ui-icons_454545_256x240.png permanent;
-  rewrite ^/ui/_images/ui-bg_glass_75_dadada_1x400\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_glass_75_dadada_1x400.png permanent;
-  rewrite ^/ui/_images/ui-bg_flat_0_aaaaaa_40x100\.png$ https://releases.jquery.com/git/ui/_images/ui-bg_flat_0_aaaaaa_40x100.png permanent;
-
-  #error_page    404              /404.html;
+  # New-style /git/ URLs as of March 2021
+  #
+  # This must "win" over the "-git" location match as otherwise
+  # we would wrongly send "/git/foo-git.js" to "/git/git/foo-git.js"
+  #
+  # Achieved by using the `^~` operator instead of a simple prefix match,
+  # because `^~` has priority over `~*`.
+  #
+  # Ref https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms#how-nginx-chooses-which-location-to-use-to-handle-requests
+  #
+  location ^~ /git/ { return 301 https://releases.jquery.com$uri; }
 
   # redirect server error pages to the static page /50x.html
-  #
   error_page    500 502 503 504  /50x.html;
   location = /50x.html {
     root   /usr/share/nginx/html;

--- a/test/cfg-test.php
+++ b/test/cfg-test.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Usage:
+ *
+ *     $ php test/cfp-php.php
+ *     $ php test/cfp-php.php "localhost:4000"
+ *     $ TEST_SERVER="localhost:4000" php test/cfp-php.php
+ */
+
+$server = getenv( 'TEST_SERVER' ) ?: @$argv[1] ?: 'localhost:4000';
+
+Unit::start();
+
+// Domain root
+
+Unit::testHttp( $server, '/', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/',
+] );
+
+// Static assets
+
+Unit::testHttp( $server, '/jquery-3.0.0.js', [
+	'status' => '200 OK',
+	'server' => 'nginx',
+	'content-type' => 'application/javascript; charset=utf-8',
+	'content-length' => '263268',
+	'last-modified' => 'Fri, 18 Oct 1991 12:00:00 GMT',
+	'connection' => 'keep-alive',
+	'vary' => 'Accept-Encoding',
+	'etag' => '"28feccc0-40464"',
+	'expires' => 'Thu, 31 Dec 2037 23:55:55 GMT',
+	'cache-control' => 'max-age=315360000, public',
+	'access-control-allow-origin' => '*',
+	'accept-ranges' => 'bytes',
+] );
+
+Unit::testHttp( $server, '/qunit/qunit-2.0.0.css', [
+	'status' => '200 OK',
+	'server' => 'nginx',
+	'content-type' => 'text/css',
+	'content-length' => '7456',
+	'last-modified' => 'Fri, 18 Oct 1991 12:00:00 GMT',
+	'connection' => 'keep-alive',
+	'vary' => 'Accept-Encoding',
+	'etag' => '"28feccc0-1d20"',
+	'expires' => 'Thu, 31 Dec 2037 23:55:55 GMT',
+	'cache-control' => 'max-age=315360000, public',
+	'access-control-allow-origin' => '*',
+	'accept-ranges' => 'bytes',
+] );
+
+Unit::testHttp( $server, '/ui/1.10.0/themes/base/images/ui-icons_222222_256x240.png', [
+	'status' => '200 OK',
+	'server' => 'nginx',
+	'content-type' => 'image/png',
+	'content-length' => '4369',
+	'last-modified' => 'Fri, 18 Oct 1991 12:00:00 GMT',
+	'connection' => 'keep-alive',
+	'etag' => '"28feccc0-1111"',
+	'expires' => 'Thu, 31 Dec 2037 23:55:55 GMT',
+	'cache-control' => 'max-age=315360000, public',
+	'access-control-allow-origin' => '*',
+	'accept-ranges' => 'bytes',
+] );
+
+Unit::testHttp( $server, '/jquery-2.0.0.min.map', [
+	'status' => '200 OK',
+	'server' => 'nginx',
+	'content-type' => 'application/octet-stream',
+	'content-length' => '126081',
+	'last-modified' => 'Fri, 18 Oct 1991 12:00:00 GMT',
+	'connection' => 'keep-alive',
+	'etag' => '"28feccc0-1ec81"',
+	'expires' => 'Thu, 31 Dec 2037 23:55:55 GMT',
+	'cache-control' => 'max-age=315360000, public',
+	'access-control-allow-origin' => '*',
+	'accept-ranges' => 'bytes',
+] );
+
+// Renamed files
+
+Unit::testHttp( $server, '/jquery-git2.js', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://code.jquery.com/jquery-git.js',
+] );
+
+// Moved to releases, WordPress page
+
+Unit::testHttp( $server, '/jquery/', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/jquery/',
+] );
+
+// Moved to releases, WordPress page without trailing slash
+
+Unit::testHttp( $server, '/jquery', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/jquery/',
+] );
+
+// Moved to releases, root -git file
+
+Unit::testHttp( $server, '/jquery-git.js', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/jquery-git.js',
+] );
+
+// Moved to releases, nested -git file
+
+Unit::testHttp( $server, '/color/jquery.color-git.min.js', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/color/jquery.color-git.min.js',
+] );
+
+Unit::testHttp( $server, '/qunit/qunit-git.css', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/qunit/qunit-git.css',
+] );
+
+Unit::testHttp( $server, '/mobile/git/jquery.mobile-git.min.map', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/mobile/git/jquery.mobile-git.min.map',
+] );
+
+// Moved to releases, any file under /mobile/git
+
+Unit::testHttp( $server, '/mobile/git/images/icons-png/power-black.png', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/mobile/git/images/icons-png/power-black.png',
+] );
+
+// Moved to releases, any file under /git (new-style URL)
+
+Unit::testHttp( $server, '/git/qunit/qunit-git.css', [
+	'status' => '301 Moved Permanently',
+	'server' => 'nginx',
+	'location' => 'https://releases.jquery.com/git/qunit/qunit-git.css',
+] );
+
+Unit::end();
+
+function jq_req( $url ) {
+	print "# $url\n";
+	$ch = curl_init( $url );
+	$resp = [ 'headers' => [], 'body' => null ];
+	curl_setopt_array( $ch, [
+		CURLOPT_RETURNTRANSFER => 1,
+		CURLOPT_FOLLOWLOCATION => 0,
+		CURLOPT_HEADERFUNCTION => function( $ch, $header ) use ( &$resp ) {
+			$len = strlen( $header );
+			if ( preg_match( "/^(HTTP\/(?:1\.[01]|2)) (\d{3} .*)/", $header, $m ) ) {
+				$resp['headers'] = [];
+				$resp['headers']['status'] = trim( $m[2] );
+			} else {
+				$parts = explode( ':', $header, 2 );
+				if ( count( $parts ) === 2 ) {
+					$name = strtolower( $parts[0] );
+					$val = trim( $parts[1] );
+					if ( isset( $resp['headers'][$name] ) ) {
+						$resp['headers'][$name] .= ", $val";
+					} else {
+						$resp['headers'][$name] = $val;
+					}
+				}
+			}
+			return $len;
+		},
+	] );
+	$resp['body'] = curl_exec( $ch );
+	curl_close( $ch );
+	return $resp;
+}
+
+class Unit {
+	static $i = 0;
+	static $pass = true;
+
+	public static function start() {
+		print "TAP version 13\n";
+	}
+
+	public static function test( $name, $actual, $expected ) {
+		$num = ++self::$i;
+		if ( $actual === $expected ) {
+			print "ok $num $name\n";
+		} else {
+			self::$pass = false;
+			print "not ok $num $name\n  ---\n  actual:   "
+				. json_encode( $actual, JSON_UNESCAPED_SLASHES ) . "\n  expected: "
+				. json_encode( $expected, JSON_UNESCAPED_SLASHES ) . "\n";
+		}
+	}
+
+	public static function testHttp( $server, $path, array $expectHeaders, $expectBody = null ) {
+		$resp = jq_req( "http://{$server}{$path}" );
+		foreach ( $expectHeaders as $key => $val ) {
+			self::test( "GET $path > header $key", @$resp['headers'][$key], $val );
+		}
+	}
+
+	public static function end() {
+		print '1..' . self::$i . "\n";
+		if ( !self::$pass ) {
+			exit( 1 );
+		}
+	}
+}


### PR DESCRIPTION
TLDR:

* Fix all the headers for correctness (mime + charset), performance, and security.
* Use much simpler redirect logic and apply the same approach as we use today.
* Verify it all with an integration test.

### Differences in file headers

In summary:

* Missing GZIP support and no "Vary: Accept-Encoding" to avoid cache poisoning.
* Missing CORS support (Access-Control-Allow-Origin).
* Missing caching allowance (Cache-Control public 10 years, max Expires).
* Missing disablement of server_tokens.
* Missing charset utf-8.
* Unstable E-Tag and Last-Modified which would cause serious cache churn
  after every rebuild.

Status quo:

```
krinkle@wp-03:~$ curl -H 'Host: codeorigin.jquery.com' -i 'http://localhost/jquery-3.0.0.js' | head -n20

Server: nginx
Date: Mon, 16 Aug 2021 23:12:52 GMT
Connection: keep-alive
Access-Control-Allow-Origin: *
Cache-Control: max-age=315360000
Cache-Control: public
Content-Length: 263268
Content-Type: application/javascript; charset=utf-8
ETag: "28feccc0-40464"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Fri, 18 Oct 1991 12:00:00 GMT
Vary: Accept-Encoding
Accept-Ranges: bytes
```

Previously, without this patch:

```
dockerize$ curl -i 'http://localhost:4000/jquery-3.0.0.js' | head -n20

Server: nginx/1.21.1
Date: Mon, 16 Aug 2021 23:13:30 GMT
Connection: keep-alive
Content-Length: 263268
Content-Type: application/javascript
ETag: "5fdbec22-40464"
Last-Modified: Thu, 17 Dec 2020 23:39:14 GMT
Accept-Ranges: bytes
```

### Match existing Nginx config

Most of the above was addressed by simply using the same Nginx config as we have in the private infrastructure.git repo for provisioning legacy codeorigin (copied from wordpress-header.conf.erb and wp/jquery.pp, respectively).

However, the last two points (charset, and unstable etag), require additional changes.

### Nginx: charset

The default charset from Nginx differs between Debian and Alpine, possibly due to changes in some of the shared libraries. Fix this by explicitly setting `charset utf-8`. Note that this does (and should) only apply to files with a MIME type in `charset_types` list, which by default contains HTML, JS, and CSS.

More importantly, it does not (and should not) cause PNG files and other binary assets to be served with a charset, which would be wrong.

### Nginx: E-Tag and Last-Modified

This was a tricky one. Git does not store file modification timestamps, which means the on-disk file mtimes are somewhat arbitrarily set to when the file was created by the local Git client. For most files, this means the time you cloned the repository, and for files added later, the time you ran `git pull`.

This was de-facto "stable" on the legacy server because it is a persistent server with a persistent git directory (we always use the same clone and just update it to fetch new files after a commit happens). The timestamps themselves don't matter
as long as they remain constant for any given file, and they were.

This is important because E-Tag is computed in Nginx based on file mtime and size and (unlike Apache) this behaviour is not configurable in Nginx (e.g. to make it compute a content hash instead). And Last-Modified naturally uses the
mtime as well.

As a workaround, I've added a `touch` command to assign all CDN files a fixed timestamp far in the past. This is safe for us because all files are expected to remain static. Even if we would change a file, it wouldn't propagate to the CDN without a manual CDN API purge (given the all-important high values for Cache-Control max-age and Expires), and after that would not propagate to any browser that has previously fetched it unless the user clears their own cache (given the all-important Cache-Control telling the browser to re-use the file blindly, which is critical for performance). As such, whether the timestamp remains constant or changes after the file is changed, would make no difference for how it propagates.

### New state

After, with this patch (and verified by a simple test suite).

```
dockerize$ curl -i 'http://localhost:4000/jquery-3.0.0.js' | head -n20

Server: nginx
Date: Mon, 16 Aug 2021 23:49:43 GMT
Connection: keep-alive
Access-Control-Allow-Origin: *
Cache-Control: max-age=315360000
Cache-Control: public
Content-Length: 263268
Content-Type: application/javascript; charset=utf-8
ETag: "28feccc0-40464"
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Last-Modified: Fri, 18 Oct 1991 12:00:00 GMT
Vary: Accept-Encoding
Accept-Ranges: bytes
```

### Misc changes

* Remove left-over Nginx config for purge.php.

* Remove left-over php-fpm script.

* Use our own document root at /var/www/cdn instead of mixing our files into the default /usr/share/nginx/html/ which contains files from the "docker-nginx" project that we may not want to serve blindly.
  This mainly affects the odd index.html file that could otherwise be served.

* Pin the Nginx base image version at 1.x. This is mostly a no-op since they've been on 1.x for 10 years, but if it does rollover
  we wouldn't want an unmanaged upgrade to a new major version. We could pun this more narrowly at some point, but 1.x should be fine for now.

* Invert the config file (let Dockerfile remove code instead of comment out) so that the most critical lines can be easily
  linted.

* Ensure all files listed are redirected correctly, as per https://github.com/jquery/infrastructure/issues/474#issuecomment-844582865  and verify this with an integration test. The expected values are populated based on running `curl` against localhost from a shell on the legacy codeorigin. I specifically did not compare against live code.jquery.com, since we care about matching what we feed to the CDN (although the above problems were surfacing through there as well). Some of the CDN behaviours can't and don't need to be mimicked from the origin. Prior to launch we will (also) compare the live code.jquery.com against the new staging CDN endpoint, but that's separate from the test for the container.

Ref https://github.com/jquery/infrastructure/issues/474.