### PR TITLE
test: support https protocol

### DIFF
--- a/test/CodeoriginTest.php
+++ b/test/CodeoriginTest.php
@@ -4,13 +4,14 @@
  *
  *     $ php test/CodeoriginTest.php
  *
- *     $ php test/CodeoriginTest.php "localhost:4000"
+ *     $ php test/CodeoriginTest.php "http://localhost:4000"
  *
- *     $ php test/CodeoriginTest.php "code.jquery.com"
+ *     $ php test/CodeoriginTest.php "http://code.jquery.com"
+ *     $ php test/CodeoriginTest.php "https://code.jquery.com"
  */
 
 require_once __DIR__ . '/Unit.php';
-$server = @$argv[1] ?: 'localhost:4000';
+$server = @$argv[1] ?: 'http://localhost:4000';
 
 Unit::start();
 

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -76,7 +76,7 @@ class Unit {
 
 	public static function testHttp( $server, $path, array $reqHeaders, array $expectHeaders, $expectBody = null ) {
 		try {
-			$resp = jq_req( "http://{$server}{$path}", $reqHeaders );
+			$resp = jq_req( "{$server}{$path}", $reqHeaders );
 			foreach ( $expectHeaders as $key => $val ) {
 				// Tolerate E-Tag weakning (which Highwinds CDN does)
 				if ( $key == 'etag' ) {


### PR DESCRIPTION
Updates the test script to require passing a protocol instead of
assuming everything is done over plain http.
