### PR TITLE
Build: Add support for "module" link on QUnit pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -311,12 +311,18 @@ grunt.registerTask( "build-index", function() {
 	}
 
 	function getQunitData() {
-		var files = grunt.file.expand( "cdn/qunit/*.js" ),
-			releases = parseReleases( files,
-				/(qunit\/qunit-(\d+\.\d+\.\d+(?:[A-z-]+\.\d+)?)(?:\.(min))?\.js)$/ );
+		const files = grunt.file.expand( "cdn/qunit/*.js" );
+		const releases = parseReleases(
+			files,
+			/(qunit\/qunit-(\d+\.\d+\.\d+(?:[A-z-]+\.\d+)?)(?:\.(min))?\.js)$/
+		);
 
 		releases.forEach( function( release ) {
 			release.theme = release.filename.replace( ".js", ".css" );
+			const moduleFilename = release.filename.replace( ".js", ".module.js" );
+			if ( files.includes( "cdn/" + moduleFilename ) ) {
+				release.module = moduleFilename;
+			}
 		} );
 
 		return {

--- a/templates/qunit-release.hbs
+++ b/templates/qunit-release.hbs
@@ -1,5 +1,6 @@
 <li>
 	QUnit {{version}} -
-	{{cdnSriLink filename "script"}},
+	{{cdnSriLink filename "script"}},{{#if module}}
+	{{cdnSriLink module "module"}},{{/if}}
 	{{cdnLink theme "stylesheet"}}
 </li>


### PR DESCRIPTION
First released with QUnit 3.0.0-alpha.4.

Test plan:

* `module` key is set in `cdn.json` data for QUnit 3.0.0-alpha.4, not for older releases.
* `module` link is included on `qunit.html` for QUnit 3.0.0-alpha.4, not for other releases.

```js
$ npm install && npx grunt build
…
$ less dist/wordpress/resources/cdn.json
$ less dist/wordpress/posts/page/qunit.html
```
```json
  "qunit": {
    "latestStable": {
      "filename": "qunit/qunit-2.22.0.js",
      "version": "2.22.0",
      "theme": "qunit/qunit-2.22.0.css"
    },
    "all": [
      {
        "filename": "qunit/qunit-3.0.0-alpha.4.js",
        "version": "3.0.0-alpha.4",
        "theme": "qunit/qunit-3.0.0-alpha.4.css",
        "module": "qunit/qunit-3.0.0-alpha.4.module.js"
      },
      {
        "filename": "qunit/qunit-3.0.0-alpha.3.js",
        "version": "3.0.0-alpha.3",
        "theme": "qunit/qunit-3.0.0-alpha.3.css"
      },
```
```html
<h2>QUnit - All Versions</h2>
<ul>
	<li>
	QUnit 3.0.0-alpha.4 -
	<a
			class='open-sri-modal'
			href='https://code.jquery.com/qunit/qunit-3.0.0-alpha.4.js'
			data-hash='sha256-VKxoHCY02QAnjeQaJ+xYA/kfZTAlzN6n8qP+SDvVI7Y='
		>script</a>,
	<a
			class='open-sri-modal'
			href='https://code.jquery.com/qunit/qunit-3.0.0-alpha.4.module.js'
			data-hash='sha256-XHulKlQYLHGDuBSpNK5BBykG1VB15lfYHlx3iF0nan0='
		>module</a>,
	<a href='https://code.jquery.com/qunit/qunit-3.0.0-alpha.4.css'>stylesheet</a>
</li>
<li>
	QUnit 3.0.0-alpha.3 -
	<a
			class='open-sri-modal'
			href='https://code.jquery.com/qunit/qunit-3.0.0-alpha.3.js'
			data-hash='sha256-cgHZe4kjOb6ZUMVxlAKMr7f5+0CqPxl6GzN32diU2n4='
		>script</a>,
	<a href='https://code.jquery.com/qunit/qunit-3.0.0-alpha.3.css'>stylesheet</a>
</li>
…
<li>
	QUnit 2.22.0 -
	<a
			class='open-sri-modal'
			href='https://code.jquery.com/qunit/qunit-2.22.0.js'
			data-hash='sha256-N4+2khEOiYS4o7WwvBQl0xZlAddyqQYVq5NBnUdugig='
		>script</a>,
	<a href='https://code.jquery.com/qunit/qunit-2.22.0.css'>stylesheet</a>
</li>
```


Ref https://github.com/qunitjs/qunit/pull/1798.
Ref https://github.com/qunitjs/qunit/issues/1551.